### PR TITLE
Setup VS Code files and settings. No need to use Arduino IDE anymore

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,24 @@
+{
+    "configurations": [
+        {
+            "name": "Win32",
+            "includePath": [
+                "${workspaceFolder}/**",
+                "C:/Program Files (x86)/Arduino/**",
+                "C:/Users/Pavel/Documents/Arduino/**"
+            ],
+            "defines": [
+                "_DEBUG",
+                "UNICODE",
+                "_UNICODE",
+                "USBCON"
+            ],
+            "windowsSdkVersion": "10.0.18362.0",
+            "compilerPath": "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools\\VC\\Tools\\MSVC\\14.26.28801\\bin\\Hostx64\\x64\\cl.exe",
+            "cStandard": "c17",
+            "cppStandard": "c++17",
+            "intelliSenseMode": "windows-msvc-x64"
+        }
+    ],
+    "version": 4
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "cstddef": "cpp"
+    }
+}

--- a/boebot/boebot.ino
+++ b/boebot/boebot.ino
@@ -1,5 +1,6 @@
 // Robotics with the BOE Shield - MovementsWithSimpleFunctions
 // Move forward, left, right, then backward for testing and tuning.
+#include <Arduino.h>
 #include <Servo.h> // Include servo library
 //#include <SoftwareSerial.h>
  
@@ -11,11 +12,11 @@ bool b = false;
 bool c = false;
 bool d = false;
 
-byte x0 = 0;
-byte x1 = 0;
+uint8_t x0 = 0;
+uint8_t x1 = 0;
 
-byte y0 = 0;
-byte y1 = 0;
+uint8_t y0 = 0;
+uint8_t y1 = 0;
 
 int16_t x = 512;
 int16_t y = 512;

--- a/boebot_remote/boebot_remote.ino
+++ b/boebot_remote/boebot_remote.ino
@@ -1,6 +1,7 @@
 // Robotics with the BOE Shield - MovementsWithSimpleFunctions
 // Move forward, left, right, then backward for testing and tuning.
 //#include <SoftwareSerial.h>
+#include <Arduino.h>
 
 unsigned long lastSend = 0;
 unsigned long sendInterval = 25;


### PR DESCRIPTION
Arduino IDE can still be used to edit the files, they just also work in VS code as a unified "project" now.

Note: 

- To make this work in VS Code, the Arduino extension is needed.
- Arduino IDE must be installed.
- You need to modify the c_cpp_properties.json file, specifically replace my Arduino IDE path with your own and probably remove the documents reference (it's not necessary).